### PR TITLE
Introduce "gt" alias for googleTranslate in useGoogleTranslate hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ export default App;
 ```
 
 ## Translating Text
-Use the useTranslation hook to access the googleTranslate function and translate text in your components.
+Use the useGoogleTranslate hook to access the googleTranslate function and translate text in your components.
 
 ```tsx
-import { useTranslation } from 'react-google-cloud-translate';
+import { useGoogleTranslate } from 'react-google-cloud-translate';
 
 const App = () => {
   const { googleTranslate } = useGoogleTranslate();
@@ -42,6 +42,21 @@ const App = () => {
 };
 
 export default App;
+```
+
+or use `gt` function as a short alias:
+
+```tsx
+const App = () => {
+  const { gt } = useGoogleTranslate();
+  
+  return (
+    <h1>{gt('hello')}</h1>
+  );
+};
+
+export default App;
+
 ```
 
 ## Bulk Text Translation

--- a/src/lib/translation.tsx
+++ b/src/lib/translation.tsx
@@ -58,7 +58,7 @@ export const GoogleTranslateProvider: React.FC<GoogleTranslateProviderProps> = (
   );
 
   return (
-    <GoogleTranslateContext.Provider value={{ googleTranslate }}>
+    <GoogleTranslateContext.Provider value={{ googleTranslate, gt: googleTranslate }}>
       {children}
     </GoogleTranslateContext.Provider>
   );

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -23,6 +23,13 @@ export interface GoogleTranslateContextProps {
    * @example googleTranslate("hello")
   */
   googleTranslate: (word: string, disable_fetch?: boolean) => string;
+  /**
+   * Short alias for googleTranslate function. Translate a single word. Returns the untranslated word immediately, and updates later when translation is ready.
+   * @param word - The word to translate
+   * @param disable_fetch - Set to true to disable fetching from the api and rely on database only.
+   * @example gt("hello")
+  */
+  gt: (word: string, disable_fetch?: boolean) => string;
 };
 
 /** Props for GoogleTranslateProvider 


### PR DESCRIPTION
* Introduces `gt` alias for `googleTranslate` in `useGoogleTranslate` hook
* Minor correction to usage documentation in `README` file for `useTranslation`

Related: #2 